### PR TITLE
Add ability to manage products

### DIFF
--- a/app/models/product.server.ts
+++ b/app/models/product.server.ts
@@ -1,0 +1,64 @@
+import type { User, Product } from "@prisma/client";
+
+import { prisma } from "~/db.server";
+
+export function getProduct({ id }: Pick<Product, "id">) {
+  return prisma.product.findUnique({
+    where: { id },
+  });
+}
+
+export async function createProduct({
+  userId,
+  title,
+  description,
+  price,
+  discount,
+  stock,
+  listed,
+}: Product & {
+  userId: User["id"];
+}) {
+  return prisma.product.create({
+    data: {
+      title,
+      description,
+      price,
+      discount,
+      stock,
+      listed,
+      user: {
+        connect: {
+          id: userId,
+        },
+      },
+    },
+  });
+}
+
+export async function updateProduct({
+  id,
+  updates,
+}: Pick<Product, "id"> & {
+  updates: Partial<Omit<Product, "id">>;
+}) {
+  return prisma.product.update({
+    where: {
+      id,
+    },
+    data: updates,
+  });
+}
+
+export function getProductListItems({ userId }: { userId: User["id"] }) {
+  return prisma.product.findMany({
+    where: { userId },
+    orderBy: { updatedAt: "desc" },
+  });
+}
+
+export function deleteProduct({ id }: Pick<Product, "id">) {
+  return prisma.product.delete({
+    where: { id },
+  });
+}

--- a/app/routes/backoffice.products.$productId.delete.tsx
+++ b/app/routes/backoffice.products.$productId.delete.tsx
@@ -1,0 +1,11 @@
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import invariant from "tiny-invariant";
+
+import { deleteProduct } from "~/models/product.server";
+
+export const action = async ({ params }: ActionFunctionArgs) => {
+  invariant(params.productId, "Missing productId param");
+  await deleteProduct({ id: params.productId });
+  return redirect("/backoffice/products");
+};

--- a/app/routes/backoffice.products.$productId.tsx
+++ b/app/routes/backoffice.products.$productId.tsx
@@ -1,0 +1,50 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+import invariant from "tiny-invariant";
+
+import { getProduct } from "~/models/product.server";
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  invariant(params.productId, "productId not found");
+
+  const product = await getProduct({ id: params.productId });
+  if (!product) {
+    throw new Response("Not Found", { status: 404 });
+  }
+  return json({ product });
+};
+
+export default function ProductDetailsPage() {
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <div>
+      <div className="flex flex-row">
+        <h3 className="text-2xl font-bold">{data.product.title}</h3>
+        <Form action="edit" method="get">
+          <button
+            data-cy="edit"
+            type="submit"
+            className="rounded px-2 py-2 text-white focus:bg-blue-400"
+            aria-label="edit"
+          >
+            ✏️
+          </button>
+        </Form>
+        <Form action="delete" method="post">
+          <button
+            data-cy="delete"
+            type="submit"
+            className="rounded px-2 py-2 text-white focus:bg-blue-400"
+            aria-label="delete"
+          >
+            🗑️
+          </button>
+        </Form>
+      </div>
+      <p className="py-6">{data.product.description}</p>
+      <hr className="my-4" />
+    </div>
+  );
+}

--- a/app/routes/backoffice.products.$productId_.edit.tsx
+++ b/app/routes/backoffice.products.$productId_.edit.tsx
@@ -1,10 +1,12 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import { Form, useLoaderData } from "@remix-run/react";
+import invariant from "tiny-invariant";
 
 import { getProduct, updateProduct } from "~/models/product.server";
 
 export const action = async ({ params, request }: ActionFunctionArgs) => {
+  invariant(params.productId, "Missing productId param");
   const formData = await request.formData();
   const updates = Object.fromEntries(formData);
   const price = parseFloat(formData.get("price"));

--- a/app/routes/backoffice.products.$productId_.edit.tsx
+++ b/app/routes/backoffice.products.$productId_.edit.tsx
@@ -1,0 +1,148 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
+import { getProduct, updateProduct } from "~/models/product.server";
+
+export const action = async ({ params, request }: ActionFunctionArgs) => {
+  const formData = await request.formData();
+  const updates = Object.fromEntries(formData);
+  const price = parseFloat(formData.get("price"));
+  const discount = parseFloat(formData.get("discount"));
+  const stock = parseInt(formData.get("stock"), 10);
+  const listed = formData.get("listed") === "on" ? true : false;
+
+  const product = await updateProduct({
+    id: params.productId,
+    updates: {
+      ...updates,
+      price,
+      discount,
+      stock,
+      listed,
+    },
+  });
+
+  if (!product) {
+    return null;
+  }
+
+  return redirect(`/backoffice/products`);
+};
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const product = await getProduct({ id: params.productId });
+  if (!product) {
+    throw new Response("Not Found", { status: 404 });
+  }
+  return json({ product });
+};
+
+export default function EditProduct() {
+  const { product } = useLoaderData<typeof loader>();
+
+  return (
+    <Form
+      method="post"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        width: "100%",
+      }}
+    >
+      {/* Title */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Title: </span>
+          <input
+            defaultValue={product.title}
+            name="title"
+            data-cy="title"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Description */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Description: </span>
+          <textarea
+            defaultValue={product.description}
+            data-cy="description"
+            name="description"
+            rows={6}
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Price */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Price: </span>
+          <input
+            name="price"
+            defaultValue={product.price}
+            data-cy="price"
+            type="number"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Discount */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Discount: </span>
+          <input
+            name="discount"
+            defaultValue={product.discount}
+            data-cy="discount"
+            type="number"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Stock */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Stock: </span>
+          <input
+            name="stock"
+            defaultValue={product.stock}
+            type="number"
+            data-cy="stock"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Listed */}
+      <div>
+        <label className="">
+          <span>Listed: </span>
+          <input
+            name="listed"
+            checked={product.listed}
+            data-cy="listed"
+            type="checkbox"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      <div className="text-right">
+        <button
+          type="submit"
+          data-cy="save"
+          className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 focus:bg-blue-400"
+        >
+          Save
+        </button>
+      </div>
+    </Form>
+  );
+}

--- a/app/routes/backoffice.products.new.tsx
+++ b/app/routes/backoffice.products.new.tsx
@@ -1,0 +1,133 @@
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
+
+import { createProduct } from "~/models/product.server";
+import { requireUserId } from "~/session.server";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const userId = await requireUserId(request);
+
+  const formData = await request.formData();
+  const updates = Object.fromEntries(formData);
+  const price = parseFloat(formData.get("price"));
+  const discount = parseFloat(formData.get("discount"));
+  const stock = parseInt(formData.get("stock"), 10);
+  const listed = formData.get("listed") === "on" ? true : false;
+
+  const product = await createProduct({
+    ...updates,
+    userId,
+    price,
+    discount,
+    stock,
+    listed,
+  });
+
+  if (!product) {
+    return null;
+  }
+
+  return redirect(`/backoffice/products`);
+};
+
+export default function NewProductPage() {
+  return (
+    <Form
+      method="post"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        width: "100%",
+      }}
+    >
+      {/* Title */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Title: </span>
+          <input
+            name="title"
+            data-cy="title"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Description */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Description: </span>
+          <textarea
+            name="description"
+            rows={6}
+            data-cy="description"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Price */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Price: </span>
+          <input
+            name="price"
+            type="number"
+            data-cy="price"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Discount */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Discount: </span>
+          <input
+            name="discount"
+            type="number"
+            data-cy="discount"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Stock */}
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Stock: </span>
+          <input
+            name="stock"
+            type="number"
+            data-cy="stock"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      {/* Listed */}
+      <div>
+        <label className="">
+          <span>Listed: </span>
+          <input
+            name="listed"
+            type="checkbox"
+            data-cy="listed"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+          />
+        </label>
+      </div>
+
+      <div className="text-right">
+        <button
+          type="submit"
+          data-cy="save"
+          className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 focus:bg-blue-400"
+        >
+          Save
+        </button>
+      </div>
+    </Form>
+  );
+}

--- a/app/routes/backoffice.products.tsx
+++ b/app/routes/backoffice.products.tsx
@@ -1,0 +1,70 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, Link, NavLink, Outlet, useLoaderData } from "@remix-run/react";
+
+import { getProductListItems } from "~/models/product.server";
+import { requireUserId } from "~/session.server";
+import { useUser } from "~/utils";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const userId = await requireUserId(request);
+  const productListItems = await getProductListItems({ userId });
+  return json({ productListItems });
+};
+
+export default function ProductsPage() {
+  const data = useLoaderData<typeof loader>();
+  const user = useUser();
+
+  return (
+    <div className="flex h-full min-h-screen flex-col">
+      <header className="flex items-center justify-between bg-slate-800 p-4 text-white">
+        <h1 className="text-3xl font-bold">
+          <Link to=".">Backoffice - Products</Link>
+        </h1>
+        <p>{user.email}</p>
+        <Form action="/logout" method="post">
+          <button
+            type="submit"
+            className="rounded bg-slate-600 px-4 py-2 text-blue-100 hover:bg-blue-500 active:bg-blue-600"
+          >
+            Logout
+          </button>
+        </Form>
+      </header>
+
+      <main className="flex h-full bg-white">
+        <div data-cy="product-list" className="h-full w-80 border-r bg-gray-50">
+          <Link to="new" className="block p-4 text-xl text-blue-500">
+            + New Product
+          </Link>
+
+          <hr />
+
+          {data.productListItems.length === 0 ? (
+            <p className="p-4">No products yet</p>
+          ) : (
+            <ol>
+              {data.productListItems.map((product) => (
+                <li key={product.id}>
+                  <NavLink
+                    className={({ isActive }) =>
+                      `block border-b p-4 text-xl ${isActive ? "bg-white" : ""}`
+                    }
+                    to={product.id}
+                  >
+                    ☕ {product.title}
+                  </NavLink>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+
+        <div className="flex-1 p-6">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/cypress/e2e/backoffice/add-product.cy.ts
+++ b/cypress/e2e/backoffice/add-product.cy.ts
@@ -1,0 +1,45 @@
+import { faker } from "@faker-js/faker";
+
+describe("Back Office - Add Product", () => {
+  // Set up test data
+  const testProduct = {
+    title: faker.lorem.words(1),
+    description: faker.lorem.sentences(1),
+    stock: "5",
+    price: "10",
+    discount: "5",
+    listed: true,
+  };
+
+  // Clean up after each test
+  afterEach(() => {
+    cy.cleanupUser();
+  });
+
+  it("should allow you to add a product", () => {
+    // Log in and navigate to the new product page
+    cy.login();
+    cy.visitAndCheck("/backoffice/products/new");
+
+    // Fill out the product form
+    cy.get('[data-cy="title"]').type(testProduct.title);
+    cy.get('[data-cy="description"]').type(testProduct.description);
+    cy.get('[data-cy="price"]').type(testProduct.price);
+    cy.get('[data-cy="discount"]').type(testProduct.discount);
+    cy.get('[data-cy="stock"]').type(testProduct.stock);
+    if (testProduct.listed) {
+      cy.get('[data-cy="listed"]').check();
+    } else {
+      cy.get('[data-cy="listed"]').uncheck();
+    }
+
+    // Submit the form
+    cy.get('[data-cy="save"]').click();
+
+    // Verify the product has been added
+    cy.visitAndCheck("/backoffice/products");
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.contains(testProduct.title).should("exist");
+    });
+  });
+});

--- a/cypress/e2e/backoffice/delete-product.cy.ts
+++ b/cypress/e2e/backoffice/delete-product.cy.ts
@@ -1,0 +1,49 @@
+import { faker } from "@faker-js/faker";
+
+describe("Back Office - Delete Product", () => {
+  // Set up test data
+  const testProduct = {
+    title: faker.lorem.words(1),
+    description: faker.lorem.sentences(1),
+    stock: "5",
+    price: "10",
+    discount: "5",
+    listed: true,
+  };
+
+  // Clean up after each test
+  afterEach(() => {
+    cy.cleanupUser();
+  });
+
+  it("should allow you to delete a product", () => {
+    // Log in and navigate to the new product page
+    cy.login();
+    cy.visitAndCheck("/backoffice/products/new");
+
+    // Fill out the product form
+    cy.get('[data-cy="title"]').type(testProduct.title);
+    cy.get('[data-cy="description"]').type(testProduct.description);
+    cy.get('[data-cy="price"]').type(testProduct.price);
+    cy.get('[data-cy="discount"]').type(testProduct.discount);
+    cy.get('[data-cy="stock"]').type(testProduct.stock);
+    if (testProduct.listed) {
+      cy.get('[data-cy="listed"]').check();
+    } else {
+      cy.get('[data-cy="listed"]').uncheck();
+    }
+
+    // Submit the form
+    cy.get('[data-cy="save"]').click();
+
+    // Delete the product
+    cy.visitAndCheck("/backoffice/products");
+    cy.contains(testProduct.title).click();
+    cy.get('[data-cy="delete"]').click();
+
+    // Verify the product has been deleted
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.contains(testProduct.title).should("not.exist");
+    });
+  });
+});

--- a/cypress/e2e/backoffice/edit-product.cy.ts
+++ b/cypress/e2e/backoffice/edit-product.cy.ts
@@ -1,0 +1,55 @@
+import { faker } from "@faker-js/faker";
+
+describe("Back Office - Edit Product", () => {
+  // Set up test data
+  const testProduct = {
+    title: faker.lorem.words(1),
+    newTitle: faker.lorem.words(1),
+    description: faker.lorem.sentences(1),
+    stock: "5",
+    price: "10",
+    discount: "5",
+    listed: true,
+  };
+
+  // Clean up after each test
+  afterEach(() => {
+    cy.cleanupUser();
+  });
+
+  it("should allow you to edit a product", () => {
+    cy.login();
+    // Log in and navigate to the new product page
+    cy.login();
+    cy.visitAndCheck("/backoffice/products/new");
+
+    // Fill out the product form
+    cy.get('[data-cy="title"]').type(testProduct.title);
+    cy.get('[data-cy="description"]').type(testProduct.description);
+    cy.get('[data-cy="price"]').type(testProduct.price);
+    cy.get('[data-cy="discount"]').type(testProduct.discount);
+    cy.get('[data-cy="stock"]').type(testProduct.stock);
+    if (testProduct.listed) {
+      cy.get('[data-cy="listed"]').check();
+    } else {
+      cy.get('[data-cy="listed"]').uncheck();
+    }
+
+    // Submit the form
+    cy.get('[data-cy="save"]').click();
+
+    // Edit the product's title
+    cy.visitAndCheck("/backoffice/products");
+    cy.contains(testProduct.title).click();
+    cy.get('[data-cy="edit"]').first().click();
+    cy.url().should("include", "/edit");
+    cy.get('[data-cy="title"]').clear();
+    cy.get('[data-cy="title"]').type(testProduct.newTitle);
+    cy.get('[data-cy="save"]').click();
+
+    // Verify the product's title has been updated
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.contains(testProduct.newTitle).should("exist");
+    });
+  });
+});

--- a/cypress/e2e/backoffice/list-products.cy.ts
+++ b/cypress/e2e/backoffice/list-products.cy.ts
@@ -1,0 +1,37 @@
+import { faker } from "@faker-js/faker";
+
+describe("Back Office - List Products", () => {
+  afterEach(() => {
+    cy.cleanupUser();
+  });
+
+  const testProduct = {
+    title: faker.lorem.words(1),
+    description: faker.lorem.sentences(1),
+    variant: "small",
+    category: "iced",
+    stock: 5,
+    price: 10,
+    discount: 5,
+  };
+
+  it("should allow you to see a list of products", () => {
+    cy.login();
+
+    cy.visitAndCheck("/backoffice/products/new");
+
+    // fill out form
+    cy.get('[data-cy="title"]').type(testProduct.title);
+    cy.get('[data-cy="description"]').type(testProduct.description);
+    cy.get('[data-cy="stock"]').type(testProduct.stock);
+    cy.get('[data-cy="price"]').type(testProduct.price);
+    cy.get('[data-cy="discount"]').type(testProduct.discount);
+    cy.get('[data-cy="listed"]').check();
+
+    cy.get('[data-cy="save"]').click();
+
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.contains(testProduct.title).should("exist");
+    });
+  });
+});

--- a/cypress/e2e/products.cy.ts
+++ b/cypress/e2e/products.cy.ts
@@ -1,0 +1,69 @@
+import { faker } from "@faker-js/faker";
+describe("Back Office - Products", () => {
+  const testNote = {
+    title: faker.lorem.words(1),
+    newTitle: faker.lorem.words(1),
+    description: faker.lorem.sentences(1),
+    variant: "small",
+    category: "iced",
+    stock: 5,
+    price: 10,
+    discount: 5,
+  };
+  it.skip("should allow you to add a product", () => {
+    cy.login();
+    cy.visitAndCheck("/backoffice/products/new");
+    // fill out form
+    cy.get('[data-cy="title"]').type(testNote.title);
+    cy.get('[data-cy="description"]').type(testNote.description);
+    cy.get('[data-cy="stock"]').type(testNote.stock);
+    cy.get('[data-cy="price"]').type(testNote.price);
+    cy.get('[data-cy="discount"]').type(testNote.discount);
+    cy.get('[data-cy="listed"]').check();
+    // save
+    cy.get('[data-cy="save"]').click();
+    // todo: check if added to list of products
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.contains(testNote.title).should("exist");
+    });
+  });
+  it.skip("should display a list of products", () => {
+    cy.visitAndCheck("/backoffice/products");
+    // Verify that the table contains specific product details
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.contains(testNote.title).should("exist");
+      cy.contains(testNote.description).should("exist");
+      cy.contains(testNote.stock).should("exist");
+      cy.contains(testNote.price).should("exist");
+      cy.contains(testNote.discount).should("exist");
+      // cy.contains(testNote.listed).should("exist");
+    });
+  });
+  it.skip("should allow you to edit a product", () => {
+    cy.login();
+    cy.visitAndCheck("/backoffice/products");
+    // Execute
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.get('[data-cy="edit"]').first().click();
+    });
+    cy.url().should("include", "/edit"); // => true
+    // Execute
+    // fill out form
+    cy.get('[data-cy="title"]').clear();
+    cy.get('[data-cy="title"]').type(testNote.newTitle);
+    // Verify changes
+    // save
+    cy.get('[data-cy="save"]').click();
+    // todo: check if added to list of products
+    cy.get('[data-cy="product-list"]').within(() => {
+      cy.contains(testNote.newTitle).should("exist");
+    });
+  });
+  it.skip("should allow you to delete a product", () => {
+    cy.visitAndCheck("/backoffice/products");
+    // Delete newly created product
+    cy.get('[data-cy="products-table"]').within(() => {
+      cy.get('[data-cy="delete"]').first().click();
+    });
+  });
+});

--- a/fly.toml
+++ b/fly.toml
@@ -38,13 +38,3 @@ script_checks = [ ]
   interval = "15s"
   restart_limit = 0
   timeout = "2s"
-
-  [[services.http_checks]]
-  interval = "10s"
-  grace_period = "5s"
-  method = "get"
-  path = "/healthcheck"
-  protocol = "http"
-  timeout = "2s"
-  tls_skip_verify = false
-  headers = { }

--- a/prisma/migrations/20240526175953_/migration.sql
+++ b/prisma/migrations/20240526175953_/migration.sql
@@ -1,0 +1,46 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Password" (
+    "hash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "Password_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Note" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "Note_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "price" REAL NOT NULL,
+    "discount" REAL,
+    "stock" INTEGER NOT NULL,
+    "listed" BOOLEAN NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "Product_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Password_userId_key" ON "Password"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
 
   password Password?
   notes    Note[]
+  products Product[]
 }
 
 model Password {
@@ -29,6 +30,24 @@ model Note {
   id    String @id @default(cuid())
   title String
   body  String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String
+}
+
+model Product {
+  id          String  @id @default(cuid())
+  title       String
+  description String?
+  // todo: add variants
+  // todo: add categories
+  price       Float
+  discount    Float?
+  stock       Int
+  listed      Boolean
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
<!-- Description of what this PR contains -->
- Add ability to create, read, update, delete backoffice products

## Learnings
<!-- Your major learnings and WOW moments during this challenge -->
- GET and POST in Forms in Remix (Difference of traditional web apps vs Remix)
- Using Trailing Underscores in Remix Route Naming   
- Always include how to test in PR description

## Struggles
<!-- What did you not understand, or struggled with the most -->
- Getting a default blank page when Cypress tests are in a single file. [Loom](https://www.loom.com/share/c389d3b1f66b41389c7eaca2773f5431). [Github Gist](https://gist.github.com/rrjoson/5cefae245dfee4860fec7a7619b35594)
- (new) Understanding and fixing TS errors 

## How to Test (new)
1. Duplicate `.env`
2. Run `npm run setup`
3. Run `npm run dev`
4. Log in using credentials mentioned in README file
5. Go to /backoffice/products

## References
<!-- Resources/links you found useful while doing the challenge -->
- https://remix.run/docs/en/main/tutorials/jokes (Didn't finish. Got stuck in Prisma setup)
- https://remix.run/docs/en/main/start/tutorial (Finished)
- https://github.com/kiliman/remix-ecommerce/blob/main/app/routes/products.tsx